### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
     branches: [ main ]
   pull_request:
 
+permissions:
+  contents: read
+
 # Environment variables used across jobs
 env:
   IMAGE_NAME: ghcr.io/${{ github.repository }}
@@ -34,6 +37,9 @@ jobs:
   # Job to build and publish Docker image
   publish:
     # Only run after a successful build and only on main branch pushes
+    permissions:
+      contents: read
+      packages: write
     needs: setup-shell
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/eth-library/data-assets-pipeline/security/code-scanning/2](https://github.com/eth-library/data-assets-pipeline/security/code-scanning/2)

The best way to fix this issue is to add an explicit `permissions` block to the workflow or jobs in your `.github/workflows/ci.yml`. If most jobs only require `contents: read`, set this at the top level to cover all jobs and override with a more permissive block for jobs needing extra rights (e.g., publishing to the container registry will need `packages: write`).  
- Add a workflow-level `permissions: contents: read` at the top (before `env:` or right after `name:` and `on:`).
- For the `publish` job (which pushes container images to the GitHub Container Registry), add a `permissions` block specifying `contents: read` and `packages: write` (the minimum for the Docker login and publish steps).
- Edit only the shown lines in `.github/workflows/ci.yml`:  
  - Insert the root workflow-level `permissions:` for `contents: read`.  
  - Insert the `permissions:` block for the `publish` job between lines 36 and 37.
No additional imports or method definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
