### PR TITLE
chore(cli): suppress ASCII logo and Quick Start in CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ For working on the arca-flow CLI itself (Python, Typer + Rich), see [cli/CONTRIB
 | `DAGSTER_TEST_DATA_PATH` | Directory containing METS XML files for the sensor to monitor | `arca_flow_tests/test_data` |
 | `ARCA_FLOW_THEME` | Override terminal background detection for colours (`light` or `dark`) | unset |
 | `ARCA_FLOW_QUIET` | Set to `1` to suppress Quick Start section in `arca-flow welcome` | unset |
+| `CI` | When set (e.g. by GitHub Actions), `arca-flow welcome` also omits the startup banner and Quick Start | unset |
 | `NO_COLOR` | Set to `1` to disable all colour output (also respected in CI) | unset |
 
 Copy `.env.example` to `.env` and modify as needed.

--- a/cli/README.md
+++ b/cli/README.md
@@ -101,6 +101,7 @@ These commands show how to use tools that are available directly in your shell:
 |----------|--------|
 | `ARCA_FLOW_THEME=light\|dark` | Override terminal background detection for colours |
 | `ARCA_FLOW_QUIET=1` | Suppress Quick Start section in `arca-flow welcome` |
+| `CI` (set) | `arca-flow welcome` also omits the startup banner and Quick Start |
 | `NO_COLOR=1` | Disable all colour output (also respected in CI) |
 
 ## Contributing

--- a/cli/arca_flow_cli/banner.py
+++ b/cli/arca_flow_cli/banner.py
@@ -39,6 +39,7 @@ def render_startup_banner(
     role: str,
     logo: str,
     accent: str = "#215CAF",
+    show_logo: bool = True,
 ) -> None:
     """Render the arca-* startup identity banner.
 
@@ -48,10 +49,13 @@ def render_startup_banner(
         role: Component role (e.g. ``Orchestration Engine``).
         logo: Multi-line ASCII logo text.
         accent: Accent colour for border, title, and logo (default ETH Blue).
+        show_logo: When False, render only the identity panel (no ASCII logo
+            above it). Used in CI logs where the logo adds noise.
     """
-    indent = " " * _LOGO_INDENT
-    indented_logo = "\n".join(f"{indent}[{accent}]{line}[/]" for line in logo.splitlines())
-    console.print(indented_logo)
+    if show_logo:
+        indent = " " * _LOGO_INDENT
+        indented_logo = "\n".join(f"{indent}[{accent}]{line}[/]" for line in logo.splitlines())
+        console.print(indented_logo)
     console.print(
         Padding(
             Panel(

--- a/cli/arca_flow_cli/commands/env.py
+++ b/cli/arca_flow_cli/commands/env.py
@@ -155,8 +155,16 @@ def _env_info() -> list[tuple[str, str, str]]:
 
 def welcome() -> None:
     """Show welcome banner and environment info."""
+    in_ci = bool(os.getenv("CI"))
+
     console.print()
-    render_startup_banner(console, "arca-flow", "Orchestration Engine", _LOGO)
+    render_startup_banner(
+        console,
+        "arca-flow",
+        "Orchestration Engine",
+        _LOGO,
+        show_logo=not in_ci,
+    )
 
     console.print()
     console.print("  [title]Tools[/]")
@@ -170,7 +178,7 @@ def welcome() -> None:
     console.print("  [title]Environment[/]")
     _print_info_rows(_env_info())
 
-    if not os.getenv("ARCA_FLOW_QUIET"):
+    if not in_ci and not os.getenv("ARCA_FLOW_QUIET"):
         console.print()
         console.print("  [title]Quick Start[/]")
         console.print(f"  {'af test':<14} Run tests (pytest)")


### PR DESCRIPTION
## Summary
- `arca-flow welcome` now detects the standard `CI` env var and drops the ASCII logo + Quick Start block, keeping the identity panel and the Tools / Environment sections so CI logs stay attributable and tool versions (most useful for debugging) are visible.
- `ARCA_FLOW_QUIET` keeps its existing local meaning (suppress Quick Start only).
- `README.md` and `cli/README.md` env var tables note the new `CI` behavior.

## Test plan
- [x] `CI=1 arca-flow welcome` — no ASCII logo, no Quick Start; identity panel + Tools + Environment shown.
- [x] `arca-flow welcome` (local) — unchanged: logo, panel, Tools, Environment, Quick Start.
- [x] `ARCA_FLOW_QUIET=1 arca-flow welcome` — unchanged: logo, panel, Tools, Environment; no Quick Start.
- [x] `uv run --package arca-flow-cli pytest cli/tests/` — 43 passed.
- [x] Verify on an actual CI run that the logo is suppressed during `direnv export gha` activation.